### PR TITLE
Prepare 0.6.1 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "package",
     "run"
   ],
-  "version": "0.6.0",
+  "version": "0.6.1",
   "repository": "https://github.com/nickclaw/atom-grunt-runner",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
Also moved `6.1` tag to point to this PR commit.