### PR TITLE
Add vertical spacing for buttons in the panel

### DIFF
--- a/stylesheets/style.less
+++ b/stylesheets/style.less
@@ -54,6 +54,7 @@
 
         .btn-group .btn {
             width: 100%;
+            margin-top: 8px;
         }
     }
 

--- a/stylesheets/style.less
+++ b/stylesheets/style.less
@@ -32,6 +32,7 @@
             font-size: 10pt;
             content: "\f052";
             width: 15pt;
+            vertical-align: -webkit-baseline-middle;
         }
 
         &[data-status=loading]:before {


### PR DESCRIPTION
Currently in the panel the buttons are smashed together because they have no padding/margins, added an 8px top margin and changed the `::before` element to have a `webkit-baseline-middle` vertical alignment to keep it centered.