### PR TITLE
Add run-latest command

### DIFF
--- a/lib/grunt-runner-view.coffee
+++ b/lib/grunt-runner-view.coffee
@@ -143,6 +143,10 @@ module.exports = class ResultsView extends View
     toggleTaskList: ->
         @taskList.toggle(@)
 
+    # runs the most recent task
+    runLatestTask: ->
+        @taskList.runLatest(@)
+
     # adds an entry to the log
     # converts all newlines to <br>
     addLine:(text, type = "plain") ->

--- a/lib/grunt-runner.coffee
+++ b/lib/grunt-runner.coffee
@@ -21,6 +21,7 @@ module.exports =
         atom.commands.add 'atom-workspace', 'grunt-runner:toggle-log', @view.toggleLog.bind @view
         atom.commands.add 'atom-workspace', 'grunt-runner:toggle-panel', @view.togglePanel.bind @view
         atom.commands.add 'atom-workspace', 'grunt-runner:run', @view.toggleTaskList.bind @view
+        atom.commands.add 'atom-workspace', 'grunt-runner:run-latest', @view.runLatestTask.bind @view
 
 
     # returns a JSON object representing the packages state

--- a/lib/task-list-view.coffee
+++ b/lib/task-list-view.coffee
@@ -23,6 +23,7 @@ module.exports = class TaskListView extends SelectListView
 
     # called when an Item is selected
     confirmed:(item) ->
+        @latestItem = item
         @runner.startProcess item
         @cancel()
 
@@ -54,6 +55,13 @@ module.exports = class TaskListView extends SelectListView
                 @div class: 'primary-line', =>
                     @div =>
                         @span task
+
+    # run the latest task
+    runLatest:(runner) ->
+        if @latestItem
+            runner.startProcess @latestItem
+        else
+            @toggle runner
 
     # my empty message
     getEmptyMessage: ->


### PR DESCRIPTION
I wanted to be able to add keybindings to quickly rerun the last-used grunt rule, so I added a run-latest command. If a build has already occurred, it re-runs it. Else it pops up the pick list.

I didn't add a key binding to the repo.

There's a logic flaw in this new code. If you open the task list without having previously run anything, then run-latest, it simply closes the list and does nothing. This is suboptimal, but the change got to be more invasive if I wanted to conditionally open the list. Stuck between DRY and KISS. :) Also, that's probably low-frequency event, and the user will quickly figure out they have to choose something to run. But I wanted to point it out.

I'm a noob with Atom and coffeescript (as of yesterday!), so feel free to rip this up. Or if it's good, it'd be a pleasure to see in the main repo.