### PR TITLE
Improve Error handling

### DIFF
--- a/lib/grunt-runner-view.coffee
+++ b/lib/grunt-runner-view.coffee
@@ -81,17 +81,21 @@ module.exports = class ResultsView extends View
             Task.once require.resolve('./parse-config-task'), @path+'/Gruntfile', ({error, tasks})->
 
                 if error
-                    # failed to load Gruntfile.js, try gruntfile.js
-                    Task.once require.resolve('./parse-config-task'), @path+'/gruntfile', ({error, tasks})->
-                        
-                        # log error or add panel to workspace
-                        if error
-                            view.addLine "Error loading gruntfile: #{error}", "error"
-                            view.toggleLog()
-                        else
-                            view.addLine "Grunt file parsed, found #{tasks.length} tasks"
-                            view.tasks = tasks
-                            view.togglePanel()
+                    if error == "Gruntfile not found."
+                      # failed to load Gruntfile.js, try gruntfile.js
+                      Task.once require.resolve('./parse-config-task'), @path+'/gruntfile', ({error, tasks})->
+
+                          # log error or add panel to workspace
+                          if error
+                              view.addLine "Error loading gruntfile: #{error}", "error"
+                              view.toggleLog()
+                          else
+                              view.addLine "Grunt file parsed, found #{tasks.length} tasks"
+                              view.tasks = tasks
+                              view.togglePanel()
+                    else
+                      view.addLine "Error loading gruntfile: #{error}", "error"
+                      view.toggleLog()
                 else
                     view.addLine "Grunt file parsed, found #{tasks.length} tasks"
                     view.tasks = tasks

--- a/lib/parse-config-task.coffee
+++ b/lib/parse-config-task.coffee
@@ -15,7 +15,7 @@ module.exports = (gruntfilePath) ->
         fn = require(gruntfilePath);
     catch e
 
-    if !fn then return {error: "Gruntfile not found."}
+    if !fn then return {error: "Gruntfile not found.", path: gruntfilePath}
 
     # change dir relative to gruntfile so Grunt will load
     # npm packages and other files from correct path
@@ -25,6 +25,6 @@ module.exports = (gruntfilePath) ->
         fn(grunt)
     catch e
         error = e.code
-        return {error: "Error parsing Gruntfile. " + e.message}
+        return {error: "Error parsing Gruntfile. " + e.message, path: gruntfilePath}
 
     return {tasks: Object.keys grunt.task._tasks}


### PR DESCRIPTION
atom-grunt-runner currently assumes that the only error it could have with attempting to parse /Gruntfile is that it doesn't exist and thus any error in your /Gruntfile would result in you being told that no Gruntfile was found due to /gruntfile not existing.

This only tries /gruntfile if the error from /Gruntfile was that it could not find it.

On a side note this showed me what the error was in #64 instead of just saying that I had no gruntfile